### PR TITLE
Optimize Recharge & Update Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>xyz.grasscutters</groupId> <!-- Versions below 1.0.3-dev are on 'tech.xigam' -->
             <artifactId>grasscutter</artifactId>
-            <version>1.2.0</version> <!-- Replace with the latest version of the API. -->
+            <version>1.4.6</version> <!-- Replace with the latest version of the API. -->
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/gc/test/commands/QuickERCommand.java
+++ b/src/main/java/gc/test/commands/QuickERCommand.java
@@ -1,10 +1,10 @@
 package gc.test.commands;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.FightProperty;
+import emu.grasscutter.net.proto.PropChangeReasonOuterClass.PropChangeReason;
 import emu.grasscutter.server.packet.send.PacketAvatarFightPropUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketAvatarLifeStateChangeNotify;
 import java.util.List;
@@ -16,40 +16,8 @@ public final class QuickERCommand implements CommandHandler {
 	public void execute(Player sender, Player targetPlayer, List<String> args) {
         targetPlayer.getTeamManager().getActiveTeam().forEach(entity -> {
             boolean isAlive = entity.isAlive();
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_FIRE_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_FIRE_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_FIRE_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_ELEC_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_ELEC_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_ELEC_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_WATER_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_WATER_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_WATER_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_GRASS_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_GRASS_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_GRASS_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_WIND_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_WIND_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_WIND_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_ICE_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_ICE_ENERGY)
-            );
-            entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_ICE_ENERGY));
-            entity.setFightProperty(
-                    FightProperty.FIGHT_PROP_CUR_ROCK_ENERGY,
-                    entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_ROCK_ENERGY)
-            );
+		// Add energy via EntityAvatar
+            entity.addEnergy(100, PropChangeReason.PROP_CHANGE_REASON_ENERGY_BALL);
             entity.getWorld().broadcastPacket(new PacketAvatarFightPropUpdateNotify(entity.getAvatar(), FightProperty.FIGHT_PROP_CUR_HP));
             if (!isAlive) {
                 entity.getWorld().broadcastPacket(new PacketAvatarLifeStateChangeNotify(entity.getAvatar()));


### PR DESCRIPTION
- Update Grasscutter dependency to 1.4.6. ( Fixes #1 )
- Optimize energy recharge using EntityAvatar to skip many packets being sent.

Performance is the same: 

https://user-images.githubusercontent.com/107363768/214164456-cf75a798-78b8-4954-a16f-7f0ff582fee5.mp4

